### PR TITLE
Missing packaging in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <groupId>com.buschmais.jqassistant</groupId>
     <artifactId>bom</artifactId>
     <version>2.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
     <name>jQAssistant Bill of Materials</name>
     <url>https://jqassistant.org/</url>


### PR DESCRIPTION
BOM are usually packaged as "pom": there's no need for an additional jar artifact